### PR TITLE
update cli, stop using deprecated value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    - uses: extractions/setup-just@v1
+    - uses: extractions/setup-just@v2
     
     - name: Setup
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,13 @@ jobs:
       run: |
         source venv/bin/activate
         just lint test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,16 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - uses: extractions/setup-just@v2
     
     - name: Setup
       run: |
+        uv venv venv --python 3.10
+        source venv/bin/activate
         just setup
     - name: Test
       run: |
+        source venv/bin/activate
         just lint test

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+junit.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 
 test: lint
-	pytest tests
+	pytest tests --cov-report=xml --cov=helpers --junitxml=junit.xml -o junit_family=legacy
 
 setup:
 	uv pip install --upgrade pip wheel setuptools

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ test: lint
 
 setup:
 	# Create venv.
-	venv/bin/pip install --upgrade uv
+	pip install --upgrade uv
 	uv venv venv --python 3.10
 	. venv/bin/activate
 	venv/bin/uv pip install --upgrade pip wheel setuptools

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 
 test: lint
-	pytest tests --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+	pytest tests --cov=src --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy
 
 setup:
 	uv pip install --upgrade pip wheel setuptools

--- a/justfile
+++ b/justfile
@@ -5,19 +5,19 @@ test: lint
 setup:
 	# Create venv.
 	python3 -m venv venv
-	source venv/bin/activate
+	. venv/bin/activate
 	pip install --upgrade uv
 	uv pip install --upgrade pip wheel setuptools
 	uv pip install -r requirements.txt -r requirements-dev.txt
 
 lint:
-	source venv/bin/activate
+	. venv/bin/activate
 	black --check .
 	ruff check .
 	mypy .
 
 lint-fix:
-	source venv/bin/activate
+	. venv/bin/activate
 	black .
 	ruff check --fix .
 	ruff format .

--- a/justfile
+++ b/justfile
@@ -1,22 +1,19 @@
 
 test: lint
-	venv/bin/pytest tests
+	pytest tests
 
 setup:
-	# Create venv.
-	pip install --upgrade uv
-	uv venv venv --python 3.10
-	. venv/bin/activate
-	venv/bin/uv pip install --upgrade pip wheel setuptools
-	venv/bin/uv pip install -r requirements.txt -r requirements-dev.txt
+	uv pip install --upgrade pip wheel setuptools
+	uv pip install -r requirements.txt -r requirements-dev.txt
 
 lint:
-	venv/bin/black --check .
-	venv/bin/ruff check .
-	venv/bin/mypy .
+	. venv/bin/activate
+	black --check .
+	ruff check .
+	mypy .
 
 lint-fix:
-	venv/bin/black .
-	venv/bin/ruff check --fix .
-	venv/bin/ruff format .
-	venv/bin/mypy .
+	black .
+	ruff check --fix .
+	ruff format .
+	mypy .

--- a/justfile
+++ b/justfile
@@ -5,20 +5,17 @@ test: lint
 setup:
 	# Create venv.
 	python3 -m venv venv
-	. venv/bin/activate
-	pip install --upgrade uv
-	uv pip install --upgrade pip wheel setuptools
-	uv pip install -r requirements.txt -r requirements-dev.txt
+	venv/bin/pip install --upgrade uv
+	venv/bin/uv pip install --upgrade pip wheel setuptools
+	venv/bin/uv pip install -r requirements.txt -r requirements-dev.txt
 
 lint:
-	. venv/bin/activate
-	black --check .
-	ruff check .
-	mypy .
+	venv/bin/black --check .
+	venv/bin/ruff check .
+	venv/bin/mypy .
 
 lint-fix:
-	. venv/bin/activate
-	black .
-	ruff check --fix .
-	ruff format .
-	mypy .
+	venv/bin/black .
+	venv/bin/ruff check --fix .
+	venv/bin/ruff format .
+	venv/bin/mypy .

--- a/justfile
+++ b/justfile
@@ -5,17 +5,20 @@ test: lint
 setup:
 	# Create venv.
 	python3 -m venv venv
-	venv/bin/pip install --upgrade uv
-	venv/bin/uv pip install --upgrade pip wheel setuptools
-	venv/bin/uv pip install -r requirements.txt -r requirements-dev.txt
+	source venv/bin/activate
+	pip install --upgrade uv
+	uv pip install --upgrade pip wheel setuptools
+	uv pip install -r requirements.txt -r requirements-dev.txt
 
 lint:
-	venv/bin/black --check .
-	venv/bin/ruff check .
-	venv/bin/mypy .
+	source venv/bin/activate
+	black --check .
+	ruff check .
+	mypy .
 
 lint-fix:
-	venv/bin/black .
-	venv/bin/ruff check --fix .
-	venv/bin/ruff format .
-	venv/bin/mypy .
+	source venv/bin/activate
+	black .
+	ruff check --fix .
+	ruff format .
+	mypy .

--- a/justfile
+++ b/justfile
@@ -4,8 +4,9 @@ test: lint
 
 setup:
 	# Create venv.
-	python3 -m venv venv
 	venv/bin/pip install --upgrade uv
+	uv venv venv --python 3.10
+	. venv/bin/activate
 	venv/bin/uv pip install --upgrade pip wheel setuptools
 	venv/bin/uv pip install -r requirements.txt -r requirements-dev.txt
 

--- a/justfile
+++ b/justfile
@@ -5,15 +5,17 @@ test: lint
 setup:
 	# Create venv.
 	python3 -m venv venv
-	venv/bin/pip install --upgrade pip wheel setuptools
-	venv/bin/pip install -r requirements.txt -r requirements-dev.txt
+	venv/bin/pip install --upgrade uv
+	venv/bin/uv pip install --upgrade pip wheel setuptools
+	venv/bin/uv pip install -r requirements.txt -r requirements-dev.txt
 
 lint:
 	venv/bin/black --check .
-	venv/bin/ruff .
+	venv/bin/ruff check .
 	venv/bin/mypy .
 
 lint-fix:
 	venv/bin/black .
-	venv/bin/ruff .
+	venv/bin/ruff check --fix .
+	venv/bin/ruff format .
 	venv/bin/mypy .

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 
 test: lint
-	pytest tests --cov-report=xml --cov=helpers --junitxml=junit.xml -o junit_family=legacy
+	pytest tests --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
 setup:
 	uv pip install --upgrade pip wheel setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 dbt-core
 black
 ruff==0.9.6
-pytest
+pytest==8.3.4
+pytest-cov==6.0.0
 mypy
 types-PyYAML

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 dbt-core
 black
-ruff
+ruff==0.9.6
 pytest
 mypy
 types-PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-acryl-datahub==0.10.4.3
+acryl-datahub==0.14.1.12

--- a/src/impact_analysis.py
+++ b/src/impact_analysis.py
@@ -61,12 +61,16 @@ def determine_changed_dbt_models() -> List[DbtNodeInfo]:
                 "ls",
                 # fmt: off
                 # Use the manifest file from the previous run.
-                "-s", "state:modified",
+                "-s",
+                "state:modified",
                 # Limit to desired node types.
-                "--resource-type", "model",
-                "--resource-type", "snapshot",
+                "--resource-type",
+                "model",
+                "--resource-type",
+                "snapshot",
                 # Output formatting.
-                "--output", "json",
+                "--output",
+                "json",
                 # With dbt 1.4, these were comma-separated and needed to be quoted so that
                 # they go in as a single arg. With dbt 1.5, it's a list that go in
                 # as separate args. To avoid the headache, we'll just get the full
@@ -115,7 +119,7 @@ def find_datahub_urns(graph: DataHubGraph, dbt_node_ids: List[str]) -> List[str]
     filter_conditions = [
         {
             "field": "customProperties",
-            "value": f"{DBT_ID_PROP}={dbt_node_id}",
+            "values": [f"{DBT_ID_PROP}={dbt_node_id}"],
             "condition": "EQUAL",
         }
         for dbt_node_id in dbt_node_ids


### PR DESCRIPTION
- use `uv` instead of `pip` locally
- set specific version of `ruff` and update commands
- update CLI in `requirments.txt` to be a new one
- run formatting on files
- stop using deprecated `value` parameter and start using `values` parameter
- add codecov