### PR TITLE
Rename github_base_ref input parameter to avoid naming collision 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         DATAHUB_GMS_TOKEN: ${{ inputs.datahub_gms_token }}
         DATAHUB_FRONTEND_URL: ${{ inputs.datahub_frontend_url }}
         GITHUB_ACTION_PATH: ${{ github.action_path }}
-        GITHUB_BASE_REF: ${{ inputs.github_base_ref }}
+        DBT_GITHUB_BASE_REF: ${{ inputs.github_base_ref }}
         DEBUG_MODE: ${{ inputs.debug_mode }}
         MAX_IMPACTED_DOWNSTREAMS: ${{ inputs.max_impacted_downstreams }}
 

--- a/src/impact_analysis.sh
+++ b/src/impact_analysis.sh
@@ -29,10 +29,6 @@ if [ "${DEBUG_MODE}" = "true" ]; then
 	cat "${DBT_PROFILES_DIR}/profiles.yml"
 fi
 
-echo "=== DEBUG: Git checkout section ==="
-echo "DEBUG: DBT_GITHUB_BASE_REF value: '${DBT_GITHUB_BASE_REF}'"
-echo "=== END DEBUG ==="
-
 # Generate the previous manifest.
 git checkout "${DBT_GITHUB_BASE_REF}"
 dbt ls

--- a/src/impact_analysis.sh
+++ b/src/impact_analysis.sh
@@ -29,6 +29,33 @@ if [ "${DEBUG_MODE}" = "true" ]; then
 	cat "${DBT_PROFILES_DIR}/profiles.yml"
 fi
 
+echo "=== DEBUG: Git checkout section ==="
+echo "DEBUG: All environment variables containing 'REF':"
+env | grep -i ref || echo "No REF variables found"
+
+echo "DEBUG: GITHUB_BASE_REF value: '${GITHUB_BASE_REF}'"
+echo "DEBUG: GITHUB_BASE_REF length: ${#GITHUB_BASE_REF}"
+echo "DEBUG: GITHUB_BASE_REF type: $(declare -p GITHUB_BASE_REF 2>/dev/null || echo 'variable not declared')"
+
+# Check if variable is actually set
+if [ -z "${GITHUB_BASE_REF}" ]; then
+    echo "DEBUG: GITHUB_BASE_REF is empty or unset!"
+else
+    echo "DEBUG: GITHUB_BASE_REF is set to: '${GITHUB_BASE_REF}'"
+fi
+
+# Show hex dump to catch invisible characters
+echo "DEBUG: GITHUB_BASE_REF hex dump:"
+echo -n "${GITHUB_BASE_REF}" | hexdump -C || echo "hexdump failed"
+
+# Show what git command will be executed
+echo "DEBUG: About to execute: git checkout '${GITHUB_BASE_REF}'"
+echo "DEBUG: Git branches available:"
+git branch -a
+
+echo "=== END DEBUG ==="
+
+
 # Generate the previous manifest.
 git checkout "${GITHUB_BASE_REF}"
 dbt ls

--- a/src/impact_analysis.sh
+++ b/src/impact_analysis.sh
@@ -30,34 +30,11 @@ if [ "${DEBUG_MODE}" = "true" ]; then
 fi
 
 echo "=== DEBUG: Git checkout section ==="
-echo "DEBUG: All environment variables containing 'REF':"
-env | grep -i ref || echo "No REF variables found"
-
-echo "DEBUG: GITHUB_BASE_REF value: '${GITHUB_BASE_REF}'"
-echo "DEBUG: GITHUB_BASE_REF length: ${#GITHUB_BASE_REF}"
-echo "DEBUG: GITHUB_BASE_REF type: $(declare -p GITHUB_BASE_REF 2>/dev/null || echo 'variable not declared')"
-
-# Check if variable is actually set
-if [ -z "${GITHUB_BASE_REF}" ]; then
-    echo "DEBUG: GITHUB_BASE_REF is empty or unset!"
-else
-    echo "DEBUG: GITHUB_BASE_REF is set to: '${GITHUB_BASE_REF}'"
-fi
-
-# Show hex dump to catch invisible characters
-echo "DEBUG: GITHUB_BASE_REF hex dump:"
-echo -n "${GITHUB_BASE_REF}" | hexdump -C || echo "hexdump failed"
-
-# Show what git command will be executed
-echo "DEBUG: About to execute: git checkout '${GITHUB_BASE_REF}'"
-echo "DEBUG: Git branches available:"
-git branch -a
-
+echo "DEBUG: DBT_GITHUB_BASE_REF value: '${DBT_GITHUB_BASE_REF}'"
 echo "=== END DEBUG ==="
 
-
 # Generate the previous manifest.
-git checkout "${GITHUB_BASE_REF}"
+git checkout "${DBT_GITHUB_BASE_REF}"
 dbt ls
 cp -r target target-previous
 git checkout -


### PR DESCRIPTION
Issue: The action fails with git checkout '' because GitHub automatically sets GITHUB_BASE_REF as an empty string on non-PR events, which overrides the action's input parameter of the same name

Fix: Renamed the environment variable in the action from GITHUB_BASE_REF to DBT_GITHUB_BASE_REF to avoid the collision with GitHub's built-in variable.